### PR TITLE
Update to Skia upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 These have been tailored to the needs of my specific projects and my not be suitable for anyone else.
 
-# Skia version
+## Skia version
 
 The Skia version with which these bindings have been tested is from _Wed Nov 10 21:38:56 2021 +0000_
 * https://skia.googlesource.com/skia/+/6fae0523629f9abf114d8b7413f71dc7295a13e0
 * https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/4d3319e39c9b50747f47da35a351d428a38bcc82
 
-# Noticable changes in Skia code base reflected here
+## Noticable changes in Skia code base reflected here
+
+### November 10, 2021
 
 * SkFilterQuality is gone. https://skia.googlesource.com/skia/+/aebe248575affab2137f3d3fb9f94b8e397c4986

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # C bindings for Skia
+
 These have been tailored to the needs of my specific projects and my not be suitable for anyone else.
+
+# Skia version
+
+The Skia version with which these bindings have been tested is from _Wed Nov 10 21:38:56 2021 +0000_
+* https://skia.googlesource.com/skia/+/6fae0523629f9abf114d8b7413f71dc7295a13e0
+* https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/4d3319e39c9b50747f47da35a351d428a38bcc82
+
+# Noticable changes in Skia code base reflected here
+
+* SkFilterQuality is gone. https://skia.googlesource.com/skia/+/aebe248575affab2137f3d3fb9f94b8e397c4986

--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,9 @@
 set -eo pipefail
 
 # These two variables should be set in tandem to keep a consistent set of sources.
-# Last set July 13, 2021 @ 8:14pm PST
-DEPOT_TOOLS_COMMIT=a98084ce94230c828a03535a7fb2da1a1d04fe3b
-SKIA_COMMIT=97dba836328fe54df8d19e85c51226bcefd13674
+# Last set Wed Nov 10 21:38:56 2021 +0000
+DEPOT_TOOLS_COMMIT=4d3319e39c9b50747f47da35a351d428a38bcc82
+SKIA_COMMIT=6fae0523629f9abf114d8b7413f71dc7295a13e0
 
 for arg in "$@"
 do

--- a/build.sh
+++ b/build.sh
@@ -209,7 +209,9 @@ cd skia
 /bin/rm -rf src/c include/c
 cp ../../capi/sk_capi.h include/
 cp ../../capi/sk_capi.cpp src/
-grep -v "/c/" gn/core.gni | grep -v "sk_capi.cpp" | sed -e 's@skia_core_sources = \[@&\n  "$_src/sk_capi.cpp",@' >gn/core.revised.gni
+
+grep -v "/c/" gn/core.gni | grep -v "sk_capi.cpp" | sed -e 's@skia_core_sources = \[@&\
+  "$_src/sk_capi.cpp",@' >gn/core.revised.gni
 mv gn/core.revised.gni gn/core.gni
 grep -v "/c/" gn/effects.gni >gn/effects.revised.gni
 mv gn/effects.revised.gni gn/effects.gni

--- a/capi/sk_capi.cpp
+++ b/capi/sk_capi.cpp
@@ -5,7 +5,6 @@
 #include "include/core/SkColorSpace.h"
 #include "include/core/SkData.h"
 #include "include/core/SkEncodedImageFormat.h"
-#include "include/core/SkFilterQuality.h"
 #include "include/core/SkFontMetrics.h"
 #include "include/core/SkFontMgr.h"
 #include "include/core/SkPoint3.h"
@@ -147,10 +146,11 @@ static_assert((int)SkColorType::kR16G16_unorm_SkColorType       == (int)SK_COLOR
 static_assert((int)SkColorType::kA16_float_SkColorType          == (int)SK_COLOR_TYPE_A16_FLOAT,          ASSERT_ENUM_MSG(SkColorType, sk_color_type_t));
 static_assert((int)SkColorType::kR16G16_float_SkColorType       == (int)SK_COLOR_TYPE_R16G16_FLOAT,       ASSERT_ENUM_MSG(SkColorType, sk_color_type_t));
 static_assert((int)SkColorType::kR16G16B16A16_unorm_SkColorType == (int)SK_COLOR_TYPE_R16G16B16A16_UNORM, ASSERT_ENUM_MSG(SkColorType, sk_color_type_t));
+static_assert((int)SkColorType::kSRGBA_8888_SkColorType          == (int)SK_COLOR_TYPE_SRGBA_8888,        ASSERT_ENUM_MSG(SkColorType, sk_color_type_t));
 static_assert((int)SkColorType::kLastEnum_SkColorType           == (int)SK_COLOR_TYPE_LAST,               ASSERT_ENUM_MSG(SkColorType, sk_color_type_t));
 
 // sk_encoded_image_format_t
-static_assert((int)SkEncodedImageFormat::kBMP  == (int)SK_ENCODED_FORMAT_BMP,  ASSERT_ENUM_MSG(SkEncodedImageFormat, sk_encoded_image_format_t));
+static_assert((int)SkEncodedImageFormat::kBMP == (int)SK_ENCODED_FORMAT_BMP, ASSERT_ENUM_MSG(SkEncodedImageFormat, sk_encoded_image_format_t));
 static_assert((int)SkEncodedImageFormat::kGIF  == (int)SK_ENCODED_FORMAT_GIF,  ASSERT_ENUM_MSG(SkEncodedImageFormat, sk_encoded_image_format_t));
 static_assert((int)SkEncodedImageFormat::kICO  == (int)SK_ENCODED_FORMAT_ICO,  ASSERT_ENUM_MSG(SkEncodedImageFormat, sk_encoded_image_format_t));
 static_assert((int)SkEncodedImageFormat::kJPEG == (int)SK_ENCODED_FORMAT_JPEG, ASSERT_ENUM_MSG(SkEncodedImageFormat, sk_encoded_image_format_t));
@@ -167,13 +167,6 @@ static_assert((int)SkEncodedImageFormat::kHEIF == (int)SK_ENCODED_FORMAT_HEIF, A
 static_assert((int)SkFilterMode::kNearest == (int)SK_FILTER_MODE_NEAREST, ASSERT_ENUM_MSG(SkFilterMode, sk_filter_mode_t));
 static_assert((int)SkFilterMode::kLinear  == (int)SK_FILTER_MODE_LINEAR,  ASSERT_ENUM_MSG(SkFilterMode, sk_filter_mode_t));
 static_assert((int)SkFilterMode::kLast    == (int)SK_FILTER_MODE_LAST,    ASSERT_ENUM_MSG(SkFilterMode, sk_filter_mode_t));
-
-// sk_filter_quality_t
-static_assert((int)SkFilterQuality::kNone_SkFilterQuality   == (int)SK_FILTER_QUALITY_NONE,   ASSERT_ENUM_MSG(SkFilterQuality, sk_filter_quality_t));
-static_assert((int)SkFilterQuality::kLow_SkFilterQuality    == (int)SK_FILTER_QUALITY_LOW,    ASSERT_ENUM_MSG(SkFilterQuality, sk_filter_quality_t));
-static_assert((int)SkFilterQuality::kMedium_SkFilterQuality == (int)SK_FILTER_QUALITY_MEDIUM, ASSERT_ENUM_MSG(SkFilterQuality, sk_filter_quality_t));
-static_assert((int)SkFilterQuality::kHigh_SkFilterQuality   == (int)SK_FILTER_QUALITY_HIGH,   ASSERT_ENUM_MSG(SkFilterQuality, sk_filter_quality_t));
-static_assert((int)SkFilterQuality::kLast_SkFilterQuality   == (int)SK_FILTER_QUALITY_LAST,   ASSERT_ENUM_MSG(SkFilterQuality, sk_filter_quality_t));
 
 // sk_font_hinting_t
 static_assert((int)SkFontHinting::kNone   == (int)SK_FONT_HINTING_NONE,   ASSERT_ENUM_MSG(SkFontHinting, sk_font_hinting_t));

--- a/capi/sk_capi.h
+++ b/capi/sk_capi.h
@@ -346,7 +346,8 @@ typedef enum {
     SK_COLOR_TYPE_R16G16_UNORM,       // pixel with a little endian uint16_t for red and green
     SK_COLOR_TYPE_R16G16B16A16_UNORM, // pixel with a little endian uint16_t for red, green, blue and alpha
 
-    SK_COLOR_TYPE_LAST = SK_COLOR_TYPE_R16G16B16A16_UNORM,
+    SK_COLOR_TYPE_SRGBA_8888,         // pixel with 8 bits for red, green, blue, alpha; in 32-bit word with conversion between sRGB and linear space
+    SK_COLOR_TYPE_LAST = SK_COLOR_TYPE_SRGBA_8888,
 } sk_color_type_t;
 
 typedef enum {
@@ -429,16 +430,6 @@ typedef struct {
     sk_filter_mode_t     filter;
     sk_mipmap_mode_t     mipmap;
 } sk_sampling_options_t;
-
-// ===== Types from include/core/SkFilterQuality.h =====
-
-typedef enum {
-    SK_FILTER_QUALITY_NONE,   // nearest-neighbor; fastest but lowest quality
-    SK_FILTER_QUALITY_LOW,    // bilerp
-    SK_FILTER_QUALITY_MEDIUM, // bilerp + mipmaps; good for down-scaling
-    SK_FILTER_QUALITY_HIGH,   // bicubic resampling; slowest but good quality
-    SK_FILTER_QUALITY_LAST = SK_FILTER_QUALITY_HIGH
-} sk_filter_quality_t;
 
 // ===== Types from include/core/SkTypeface.h =====
 


### PR DESCRIPTION
Use a real newline in the build script to get the patch trick working on macOS
Adapt changes from the most recent version from official Skia repo.